### PR TITLE
Don't eat last line of file, if it doesn't end in \n

### DIFF
--- a/preprocessor-loader.js
+++ b/preprocessor-loader.js
@@ -92,6 +92,7 @@ module.exports = function(source) {
       lineCount++;
     }
   }
+  content = content + line;
 
   if(opt.config!==undefined && opt.cfg!==undefined && opt.cfg.regexes!==undefined) {
     for(var i=0;i<opt.cfg.regexes.length;i++) {


### PR DESCRIPTION
Very simple fix for annoying issue #1  
If a file, doesn't not end with end of line character, the preprocessor emits back the file minus last line
Please approve. 
